### PR TITLE
Workaround for ifupdown silently flaking if called too often

### DIFF
--- a/ifutil.py
+++ b/ifutil.py
@@ -203,6 +203,10 @@ def set_static(ifname, addr, netmask, gateway, nameservers):
         ifdown(ifname)
         interfaces = EtcNetworkInterfaces()
         interfaces.set_static(ifname, addr, netmask, gateway, nameservers)
+
+        # FIXME when issue in ifupdown/virtio-net becomes apparent
+        sleep(0.5)
+
         output = ifup(ifname)
 
         net = InterfaceInfo(ifname)


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/357.

Is a workaround. Sufficient until further investigation.