### PR TITLE
Display FQDN in confconsole

### DIFF
--- a/confconsole.py
+++ b/confconsole.py
@@ -295,6 +295,11 @@ class TurnkeyConsole:
             ip_addr = ifutil.get_ipconf(ifname)[0]
 
         hostname = netinfo.get_hostname().upper()
+        fqdn = netinfo.get_fqdn()
+
+        cache_dir = os.environ.get('INITHOOKS_CACHE', '/var/lib/inithooks/cache')
+        if os.path.isfile(os.path.join(cache_dir, 'APP_DOMAIN')):
+            ip_addr = fqdn
 
         try:
             #backwards compatible - use usage.txt if it exists


### PR DESCRIPTION
Display FQDN instead of ip address in confconsole if APP_DOMAIN
is set in init cache.

Closes https://github.com/turnkeylinux/tracker/issues/582
Relies on https://github.com/turnkeylinux/turnkey-pylib/pull/1
