### PR TITLE
bugfix - closes #865

### DIFF
--- a/plugins.d/Lets_Encrypt/dehydrated-wrapper
+++ b/plugins.d/Lets_Encrypt/dehydrated-wrapper
@@ -110,7 +110,7 @@ copy_if_not_found() {
 }
 
 check_80() {
-    netstat -ltpn | grep ":80 " | cut -d/ -f2 | sed -e 's|[[:space:]].*$||'
+    netstat -ltpn | grep ":80 " | head -1 | cut -d/ -f2 | sed -e 's|[[:space:]].*$||'
 }
 
 stop_server() {


### PR DESCRIPTION
For some reason, the `check_80` function was returning multiple lines on the OpenLDAP appliance (and possibly others too). This PR ensures that it uses just the first result returned.

closes https://github.com/turnkeylinux/tracker/issues/865