### PR TITLE
mail_relay: grow field_limit to 100

### DIFF
--- a/plugins.d/Mail_Relaying/mail_relay.py
+++ b/plugins.d/Mail_Relaying/mail_relay.py
@@ -73,7 +73,7 @@ def run():
             host = 'smtp-relay.sendinblue.com'
             port = '587'
 
-        field_width = field_limit = 60
+        field_width = field_limit = 100
 
         while 1:
             fields = [


### PR DESCRIPTION
Amazon SES SMTP credentials creates passwords with more than 60 chars. Grow to 100 to bit more future proof.