### PR TITLE
Update confconsole for v15.1

### DIFF
--- a/ifutil.py
+++ b/ifutil.py
@@ -5,6 +5,7 @@ from time import sleep
 
 import executil
 from netinfo import InterfaceInfo
+from netinfo import get_hostname
 
 class Error(Exception):
     pass
@@ -96,7 +97,13 @@ class EtcNetworkInterfaces:
         fh.close()
 
     def set_dhcp(self, ifname):
-        ifconf = "auto %s\niface %s inet dhcp" % (ifname, ifname)
+        hostname = get_hostname()
+        ifconf = ["auto %s\niface %s inet dhcp" % (ifname, ifname)]
+
+        if hostname:
+            ifconf.append("    hostname %s" % hostname)
+
+        ifconf = "\n".join(ifconf)
         self.write_conf(ifname, ifconf)
 
     def set_manual(self, ifname):

--- a/ifutil.py
+++ b/ifutil.py
@@ -53,11 +53,25 @@ class EtcNetworkInterfaces:
                  for line in ifconf.splitlines()
                  if line.strip().split()[0] in iface_opts ]
 
+    def _get_bridge_opts(self, ifname):
+        bridge_opts = ('bridge_ports', 'bridge_ageing', 'bridge_bridgeprio', 'bridge_fd', 'bridge_gcinit', 'bridge_hello', 'bridge_hw', 'bridge_maxage', 'bridge_maxwait', 'bridge_pathcost', 'bridge_portprio', 'bridge_stp', 'bridge_waitport')
+        if ifname not in self.conf:
+            return []
+
+        ifconf = self.conf[ifname]
+        return [ line.strip()
+                 for line in ifconf.splitlines()
+                 if line.strip().split()[0] in bridge_opts ]
+
     def write_conf(self, ifname, ifconf):
         self.read_conf()
         if not self.unconfigured:
             raise Error("refusing to write to %s\nheader not found: %s" %
                         (self.CONF_FILE, self.HEADER_UNCONFIGURED))
+
+        # carry over previously defined bridge options
+        ifconf += "\n" + "\n".join([ "    " + opt
+                                   for opt in self._get_bridge_opts(ifname) ])
 
         # carry over previously defined interface options
         ifconf += "\n" + "\n".join([ "    " + opt

--- a/plugins.d/System_Settings/hostname.py
+++ b/plugins.d/System_Settings/hostname.py
@@ -33,6 +33,14 @@ def run():
                 for line in lines:
                     fob.write(re.sub(r'myhostname =.*', 'myhostname = {}'.format(new_hostname), line))
 
+            with open('/etc/network/interfaces', 'r') as fob:
+                lines = fob.readlines()
+            with open('/etc/network/interfaces', 'w') as fob:
+                for line in lines:
+                    fob.write(re.sub(r'hostname .*', 'hostname {}'.format(new_hostname), line))
+
+            os.system('service networking restart')
+
             os.system('postfix reload')
 
             console.msgbox(TITLE, 'Hostname updated successfully. Some applications might require a relaunch before the setting applies to them.')


### PR DESCRIPTION
Closes #148 and Closes #1242

- confconsole now handles `bridge` options for LXC (and other?) appliances
- includes `hostname` option for DHCP interfaces
- restarts `networking` when `hostname` changes (sends new DHCP discover)

@JedMeister - You will still need to bump the version and do what other steps are needed to release a new Debian package.