### PR TITLE
Update Let's Encrypt integration to make the output consistent with default self-signed cert.

### DIFF
--- a/plugins.d/Lets_Encrypt/dehydrated-wrapper
+++ b/plugins.d/Lets_Encrypt/dehydrated-wrapper
@@ -37,10 +37,13 @@ SH_HOOK=$SHARE/dehydrated-confconsole.hook.sh
 SH_CRON=$SHARE/dehydrated-confconsole.cron
 SH_DOMAINS=$SHARE/dehydrated-confconsole.domains
 
-export TKL_CERTFILE="/etc/ssl/private/cert.pem"
+export TKL_CERTFILE="/usr/local/share/ca-certificates/cert.crt"
 export TKL_KEYFILE="/etc/ssl/private/cert.key"
+export TKL_COMBINED="/etc/ssl/private/cert.pem"
+export TKL_DHPARAM="/etc/ssl/private/dhparams.pem"
 cp $TKL_CERTFILE $TKL_CERTFILE.bak
 cp $TKL_KEYFILE $TKL_KEYFILE.bak
+cp $TKL_COMBINED $TKL_COMBINED.bak
 
 BASE_BIN_PATH="/usr/lib/confconsole/plugins.d/Lets_Encrypt"
 export HTTP="add-water-client"
@@ -146,12 +149,14 @@ clean_finish() {
     fi
     [ "$AUTHBIND_USR" = "$HTTP_USR" ] || chown $AUTHBIND_USR $AUTHBIND80
     if [ $EXIT_CODE -ne 0 ]; then
-        warning "Something went wrong, restoring original cert & key."
+        warning "Something went wrong, restoring original cert, key and combined files."
+
         mv $TKL_CERTFILE.bak $TKL_CERTFILE
         mv $TKL_KEYFILE.bak $TKL_KEYFILE
+        mv $TKL_COMBINED.bak $TKL_COMBINED
     else
         info "Cleaning backup cert & key"
-        rm -f $TKL_CERTFILE.bak $TKL_KEYFILE.bak
+        rm -f $TKL_CERTFILE.bak $TKL_KEYFILE.bak $TKL_COMBINED.bak
     fi
     restart_servers $WEBSERVER stunnel4
     if [ $EXIT_CODE -ne 0 ]; then

--- a/share/letsencrypt/dehydrated-confconsole.hook.sh
+++ b/share/letsencrypt/dehydrated-confconsole.hook.sh
@@ -13,7 +13,7 @@ function hook_log {
     esac
 }
 
-for var in HTTP HTTP_BIN HTTP_PID HTTP_LOG TKL_KEYFILE TKL_CERTFILE; do
+for var in HTTP HTTP_BIN HTTP_PID HTTP_LOG TKL_KEYFILE TKL_CERTFILE TKL_COMBINED TKL_DHPARAM; do
     eval "z=\$$var"
     [ -z $z ] && hook_log fatal "$var is not set. Exiting..."
 done
@@ -36,12 +36,15 @@ function clean_challenge {
 function deploy_cert {
     local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"
 
-    hook_log success "Cert request successful. Writing cert.pem & cert.key for $DOMAIN to /etc/ssl/private"
+    hook_log success "Cert request successful. Writing relevant files for $DOMAIN."
     hook_log info "fullchain: $FULLCHAIN"
     hook_log info "keyfile: $KEYFILE"
     cat "$KEYFILE" > $TKL_KEYFILE
     cat "$FULLCHAINFILE" > $TKL_CERTFILE
-    cat "$KEYFILE" >> $TKL_CERTFILE
+    cat $TKL_CERTFILE > $TKL_COMBINED
+    cat $TKL_KEYFILE >> $TKL_COMBINED
+    cat $TKL_DHPARAM >> $TKL_COMBINED
+    hook_log success "Files written/created for $DOMAIN: $TKL_CERTFILE - $TKL_KEYFILE - $TKL_COMBINED."
 }
 
 function unchanged_cert {

--- a/share/letsencrypt/dehydrated-confconsole.hook.sh
+++ b/share/letsencrypt/dehydrated-confconsole.hook.sh
@@ -41,9 +41,7 @@ function deploy_cert {
     hook_log info "keyfile: $KEYFILE"
     cat "$KEYFILE" > $TKL_KEYFILE
     cat "$FULLCHAINFILE" > $TKL_CERTFILE
-    cat $TKL_CERTFILE > $TKL_COMBINED
-    cat $TKL_KEYFILE >> $TKL_COMBINED
-    cat $TKL_DHPARAM >> $TKL_COMBINED
+    cat $TKL_CERTFILE $TKL_KEYFILE $TKL_DHPARAM  > $TKL_COMBINED
     hook_log success "Files written/created for $DOMAIN: $TKL_CERTFILE - $TKL_KEYFILE - $TKL_COMBINED."
 }
 


### PR DESCRIPTION
Update Let's Encrypt integration to make the output consistent with default self-signed cert - i.e. [`turnkey-make-ssl-cert`](https://github.com/turnkeylinux/common/blob/master/overlays/turnkey.d/sslcert/usr/local/bin/turnkey-make-ssl-cert).

Closes https://github.com/turnkeylinux/tracker/issues/1433