### PR TITLE
Autostart on login

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -36,6 +36,8 @@ class Conf:
                     self.publicip_cmd = val
                 elif op == 'networking' and val in ('true', 'false'):
                     self.networking = True if val == 'true' else False
+                elif op == 'autostart':
+                    pass
                 else:
                     raise Error("illegal configuration line: " + line)
 

--- a/conf/confconsole.conf
+++ b/conf/confconsole.conf
@@ -1,5 +1,6 @@
 # Confconsole config file
 #
+# Commented lines are ignored and default values used.
 # If value declared multiple times, the last one will be applied.
 
 # default network interface to display in usage
@@ -13,4 +14,4 @@
 #publicip_cmd ec2metadata --public-ipv4
 
 # autostart on login - one of true|once|false
-autostart once
+#autostart once

--- a/conf/confconsole.conf
+++ b/conf/confconsole.conf
@@ -1,3 +1,7 @@
+# Confconsole config file
+#
+# If value declared multiple times, the last one will be applied.
+
 # default network interface to display in usage
 #default_nic eth0
 
@@ -7,3 +11,6 @@
 # command to get public ipaddress to display in usage
 #publicip_cmd curl -s https://api.ipify.org
 #publicip_cmd ec2metadata --public-ipv4
+
+# autostart on login - one of true|once|false
+autostart once

--- a/share/autostart/confconsole-auto
+++ b/share/autostart/confconsole-auto
@@ -12,7 +12,8 @@
 #    - comment out or remove "autostart" in /etc/confconsole/confconsole.conf
 #    - make this script non-executable
 # 
-# Note that if this script is non-executable, confconsole will NOT autostart,
+# Note that if this script is non-executable, or not located in ~/.bashrc.d/
+# of a root or a sudo user account, confconsole will NOT autostart,
 # regardless of "autostart" value in /etc/confconsole/confconsole.conf.
 
 
@@ -26,6 +27,7 @@ autostart=$(grep "^autostart" $conf | tail -1 | cut -d' ' -f2)
 while true; do
     case "$autostart" in
         once)
+            # disable autostart if set to "once"
             sed -i "s|^autostart.*|autostart false|g" $conf
             break;;
         true)

--- a/share/autostart/confconsole-auto
+++ b/share/autostart/confconsole-auto
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+# Simple auto starter script for confconsole
+#
+# To enable every login:
+#    - set "autostart true" in /etc/confconsole/confconsole.conf
+#
+# To enable next login only:
+#    - set "autostart once" in /etc/confconsole/confconsole.conf; or
+#
+# To disable autostart:
+#    - set "autostart false" /etc/confconsole/confconsole.conf; or
+#    - comment out or remove "autostart" in /etc/confconsole/confconsole.conf
+#    - make this script non-executable
+# 
+# Note that if this script is non-executable, confconsole will NOT autostart,
+# regardless of "autostart" value in /etc/confconsole/confconsole.conf.
+
+
+# if "dumb" terminal (e.g. scp or others) exit straight away
+if [ "$TERM" = "dumb" ]; then
+    return
+fi
+
+conf=/etc/confconsole/confconsole.conf
+autostart=$(grep "^autostart" $conf | tail -1 | cut -d' ' -f2)
+while true; do
+    case "$autostart" in
+        once)
+            sed -i "s|^autostart.*|autostart false|g" $conf
+            break;;
+        true)
+            break;;
+        *)
+            return;;
+    esac
+done
+
+# if not root use sudo (support for sudoadmin)
+if [ "$(whoami)" != "root" ]; then
+    SUDO=sudo
+fi
+
+$SUDO confconsole


### PR DESCRIPTION
Add autostart functionality to Confconsole package. Intended default for TurnKey will be `once` (i.e. auto start on first login, but never after that).