### PR TITLE
Confconsole networking (`ifutil.py`) improvements, support for wpa_supplicant

### DIFF
--- a/ifutil.py
+++ b/ifutil.py
@@ -3,8 +3,8 @@
 
 import os
 from time import sleep
-
 import subprocess
+
 from netinfo import InterfaceInfo
 from netinfo import get_hostname
 
@@ -148,7 +148,6 @@ class EtcNetworkInterfaces:
                        f"    netmask {netmask}"])
         if gateway:
             ifconf.append(f"    gateway {gateway}")
-
         if nameservers:
             ifconf.append(f"    dns-nameservers {' '.join(nameservers)}")
 
@@ -271,7 +270,7 @@ def set_static(ifname, addr, netmask, gateway, nameservers):
 
         net = InterfaceInfo(ifname)
         if not net.addr:
-            raise IfError('Error obtaining IP address\n\n%s' % output)
+            raise IfError(f'Error obtaining IP address\n\n{output}')
 
     except Exception as e:
         return str(e)
@@ -286,7 +285,7 @@ def set_dhcp(ifname):
 
         net = InterfaceInfo(ifname)
         if not net.addr:
-            raise IfError('Error obtaining IP address\n\n%s' % output)
+            raise IfError(f'Error obtaining IP address\n\n{output}')
 
     except Exception as e:
         return str(e)
@@ -294,8 +293,8 @@ def set_dhcp(ifname):
 
 def get_ipconf(ifname, error=False):
     net = InterfaceInfo(ifname)
-    return (net.addr, net.netmask,
-            net.get_gateway(error), get_nameservers(ifname))
+    return (net.addr, net.netmask, net.get_gateway(error),
+            get_nameservers(ifname)
 
 
 def get_ifmethod(ifname):

--- a/ifutil.py
+++ b/ifutil.py
@@ -42,7 +42,7 @@ class EtcNetworkInterfaces:
                 if not line or line.startswith("#"):
                     continue
 
-                if line.startswith("auto"):
+                if line.startswith("auto") or line.startswith("allow-hotplug"):
                     ifname = line.split()[1]
                     self.conf[ifname] = line + "\n"
                 elif ifname:

--- a/ifutil.py
+++ b/ifutil.py
@@ -126,7 +126,7 @@ class EtcNetworkInterfaces:
                     or _line.startswith('dns-nameserver')):
                 continue
             else:
-                raise IfError(f'Unexpect config line: {line}')
+                raise IfError(f'Unexpected config line: {line}')
         return new_lines
 
     def set_dhcp(self, ifname: str) -> None:

--- a/ifutil.py
+++ b/ifutil.py
@@ -29,7 +29,7 @@ class EtcNetworkInterfaces:
         self.read_conf()
 
     def read_conf(self) -> None:
-        self.conf = {}
+        self.conf: dict[str, str] = {}
         self.unconfigured = False
 
         ifname = None
@@ -143,7 +143,7 @@ class EtcNetworkInterfaces:
         self.write_conf(ifname, ifconf_str)
 
     def set_static(self, ifname: str, addr: str, netmask: str,
-                   gateway: str = None, nameservers: list = []
+                   gateway: str = None, nameservers: list = None
                    ) -> None:
         ifconf = self._preproc_if(self.conf[ifname])
         ifconf[1] = f'iface {ifname} inet static'

--- a/ifutil.py
+++ b/ifutil.py
@@ -4,6 +4,7 @@
 import os
 from time import sleep
 import subprocess
+from typing import Optional
 
 from netinfo import InterfaceInfo
 from netinfo import get_hostname
@@ -27,7 +28,7 @@ class EtcNetworkInterfaces:
     def __init__(self):
         self.read_conf()
 
-    def read_conf(self):
+    def read_conf(self) -> None:
         self.conf = {}
         self.unconfigured = False
 
@@ -48,7 +49,7 @@ class EtcNetworkInterfaces:
                 elif ifname:
                     self.conf[ifname] += line + "\n"
 
-    def _get_iface_opts(self, ifname):
+    def _get_iface_opts(self, ifname: str) -> list[str]:
         iface_opts = ('pre-up', 'up', 'post-up',
                       'pre-down', 'down', 'post-down')
         if ifname not in self.conf:
@@ -59,7 +60,7 @@ class EtcNetworkInterfaces:
                 for line in ifconf.splitlines()
                 if line.strip().split()[0] in iface_opts]
 
-    def _get_bridge_opts(self, ifname):
+    def _get_bridge_opts(self, ifname: str) -> list:
         bridge_opts = ('bridge_ports', 'bridge_ageing', 'bridge_bridgeprio',
                        'bridge_fd', 'bridge_gcinit', 'bridge_hello',
                        'bridge_hw', 'bridge_maxage', 'bridge_maxwait',
@@ -73,7 +74,7 @@ class EtcNetworkInterfaces:
                 for line in ifconf.splitlines()
                 if line.strip().split()[0] in bridge_opts]
 
-    def write_conf(self, ifname, ifconf):
+    def write_conf(self, ifname: str, ifconf: str) -> None:
         self.read_conf()
         if not self.unconfigured:
             raise IfError(f"refusing to write to {self.CONF_FILE}\n"
@@ -101,7 +102,7 @@ class EtcNetworkInterfaces:
             fob.write('\n')
 
     @staticmethod
-    def _preproc_if(ifname_conf):
+    def _preproc_if(ifname_conf: str) -> list[str]:
         lines = ifname_conf.splitlines()
         if len(lines) == 2:
             return lines
@@ -128,19 +129,22 @@ class EtcNetworkInterfaces:
                 raise IfError(f'Unexpect config line: {line}')
         return new_lines
 
-    def set_dhcp(self, ifname):
+    def set_dhcp(self, ifname: str) -> None:
         ifconf = self._preproc_if(self.conf[ifname])
         ifconf[1] = f'iface {ifname} inet dhcp'
 
-        ifconf = "\n".join(ifconf)
-        self.write_conf(ifname, ifconf)
+        ifconf_str = "\n".join(ifconf)
+        self.write_conf(ifname, ifconf_str)
 
-    def set_manual(self, ifname):
+    def set_manual(self, ifname: str) -> None:
         ifconf = self._preproc_if(self.conf[ifname])
         ifconf[1] = f'iface {ifname} inet manual'
-        self.write_conf(ifname, ifconf)
+        ifconf_str = "\n".join(ifconf)
+        self.write_conf(ifname, ifconf_str)
 
-    def set_static(self, ifname, addr, netmask, gateway=None, nameservers=[]):
+    def set_static(self, ifname: str, addr: str, netmask: str,
+                   gateway: str = None, nameservers: list = []
+                   ) -> None:
         ifconf = self._preproc_if(self.conf[ifname])
         ifconf[1] = f'iface {ifname} inet static'
 
@@ -151,14 +155,14 @@ class EtcNetworkInterfaces:
         if nameservers:
             ifconf.append(f"    dns-nameservers {' '.join(nameservers)}")
 
-        ifconf = "\n".join(ifconf)
-        self.write_conf(ifname, ifconf)
+        ifconf_str = "\n".join(ifconf)
+        self.write_conf(ifname, ifconf_str)
 
 
 class EtcNetworkInterface:
     """enumerate interface information from /etc/network/interfaces"""
 
-    def __init__(self, ifname):
+    def __init__(self, ifname: str):
         self.ifname = ifname
 
         interfaces = EtcNetworkInterfaces()
@@ -167,7 +171,7 @@ class EtcNetworkInterface:
         if ifname in interfaces.conf:
             self.conflines = interfaces.conf[ifname].splitlines()
 
-    def _parse_attr(self, attr):
+    def _parse_attr(self, attr: str) -> list[str]:
         for line in self.conflines:
 
             vals = line.strip().split()
@@ -190,7 +194,7 @@ class EtcNetworkInterface:
     def dns_nameservers(self):
         return self._parse_attr('dns-nameservers')[1:]
 
-    def __getattr__(self, attrname):
+    def __getattr__(self, attrname: str) -> list[str]:
         # attributes with multiple values will be returned in an array
         # exception: dns-nameservers always returns in array (expected)
 
@@ -199,19 +203,19 @@ class EtcNetworkInterface:
         if len(values) > 2:
             return values[1:]
         elif len(values) > 1:
-            return values[1]
+            return [values[1]]
 
-        return
+        return []
 
 
-def get_nameservers(ifname):
+def get_nameservers(ifname: str) -> list[str]:
 
     # /etc/network/interfaces (static)
     interface = EtcNetworkInterface(ifname)
     if interface.dns_nameservers:
         return interface.dns_nameservers
 
-    def parse_resolv(path):
+    def parse_resolv(path: str) -> list[str]:
         nameservers = []
         with open(path, 'r') as fob:
             for line in fob:
@@ -238,26 +242,29 @@ def get_nameservers(ifname):
     return []
 
 
-def ifup(ifname):
-    return subprocess.check_output(["ifup", ifname])
+def ifup(ifname: str) -> str:
+    return subprocess.check_output(["ifup", ifname], text=True)
 
 
-def ifdown(ifname):
-    return subprocess.check_output(["ifdown", ifname])
+def ifdown(ifname: str) -> str:
+    return subprocess.check_output(["ifdown", ifname], text=True)
 
 
-def unconfigure_if(ifname):
+def unconfigure_if(ifname: str) -> Optional[str]:
     try:
         ifdown(ifname)
         interfaces = EtcNetworkInterfaces()
         interfaces.set_manual(ifname)
         subprocess.check_output(['ifconfig', ifname, '0.0.0.0'])
         ifup(ifname)
+        return None
     except subprocess.CalledProcessError as e:
         return str(e)
 
 
-def set_static(ifname, addr, netmask, gateway, nameservers):
+def set_static(ifname: str, addr: str, netmask: str,
+               gateway: str, nameservers: list[str]
+               ) -> Optional[str]:
     try:
         ifdown(ifname)
         interfaces = EtcNetworkInterfaces()
@@ -271,12 +278,12 @@ def set_static(ifname, addr, netmask, gateway, nameservers):
         net = InterfaceInfo(ifname)
         if not net.addr:
             raise IfError(f'Error obtaining IP address\n\n{output}')
-
+        return None
     except Exception as e:
         return str(e)
 
 
-def set_dhcp(ifname):
+def set_dhcp(ifname: str) -> Optional[str]:
     try:
         ifdown(ifname)
         interfaces = EtcNetworkInterfaces()
@@ -286,17 +293,18 @@ def set_dhcp(ifname):
         net = InterfaceInfo(ifname)
         if not net.addr:
             raise IfError(f'Error obtaining IP address\n\n{output}')
-
+        return None
     except Exception as e:
         return str(e)
 
 
-def get_ipconf(ifname, error=False):
+def get_ipconf(ifname: str, error: bool = False
+               ) -> tuple[str, str, str, list[str]]:
     net = InterfaceInfo(ifname)
     return (net.addr, net.netmask, net.get_gateway(error),
-            get_nameservers(ifname)
+            get_nameservers(ifname))
 
 
-def get_ifmethod(ifname):
+def get_ifmethod(ifname: str) -> str:
     interface = EtcNetworkInterface(ifname)
     return interface.method

--- a/ifutil.py
+++ b/ifutil.py
@@ -125,7 +125,7 @@ class EtcNetworkInterfaces:
                     or _line.startswith('dns-nameserver')):
                 continue
             else:
-                raise Error(f'Unexpect config line: {line}')
+                raise IfError(f'Unexpect config line: {line}')
         return new_lines
 
     def set_dhcp(self, ifname):


### PR DESCRIPTION
Refactored `ifutil.py` to support wpa_supplicant config, i.e. wlan interfaces with a line like this:
```
    wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
```
Plus other bits:
- bugfix to properly support `allow-hotplug`
- reuse existing data from interfaces conf where possible
- code style clean up
- typing