### PR TITLE
Support hosting Let's Encrypt challenges via IPv6 - closes #1785.

### DIFF
--- a/plugins.d/Lets_Encrypt/add-water-srv
+++ b/plugins.d/Lets_Encrypt/add-water-srv
@@ -113,4 +113,4 @@ if __name__ == '__main__':
 
     print("[{}] Starting Server".format(
         datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')))
-    run(host='0.0.0.0', port=80)
+    run(host='::', port=80)


### PR DESCRIPTION
Super simple fix to allow `add-water` to listen on IPv6 (as well as IPv4).

Closes https://github.com/turnkeylinux/tracker/issues/1785