### PR TITLE
Avoid an exception when quitting configuration of mail relay.

### DIFF
--- a/plugins.d/Mail_Relaying/mail_relay.py
+++ b/plugins.d/Mail_Relaying/mail_relay.py
@@ -110,7 +110,6 @@ def run():
             ]
 
             retcode, values = console.form(TITLE, FORMNOTE, fields)
-            host, port, login, password = tuple(values)
 
             if retcode != 'ok':
                 console.msgbox(TITLE,
@@ -118,7 +117,9 @@ def run():
                                ' No relaying of mail will be performed.')
                 return
 
-            elif not login:
+            host, port, login, password = tuple(values)
+
+            if not login:
                 ret = console.yesno(
                         'No login username provided. Unable to test'
                         ' SMTP connection before configuring.\n\nAre you sure'


### PR DESCRIPTION
Gracefully return to previous dialogue on form cancel.