### PR TITLE
Update ifutil.py - tweaking the ifutil to insert the hostname to corr…

### DIFF
--- a/ifutil.py
+++ b/ifutil.py
@@ -104,7 +104,7 @@ class EtcNetworkInterfaces:
     @staticmethod
     def _preproc_if(ifname_conf: str) -> list[str]:
         lines = ifname_conf.splitlines()
-        if len(lines) == 2:
+        if len(lines) == 3:
             return lines
         new_lines = []
         hostname = get_hostname()
@@ -112,9 +112,11 @@ class EtcNetworkInterfaces:
             _line = line.lstrip()
             if (_line.startswith('allow-hotplug')
                     or _line.startswith('auto')
-                    or _line.startswith('iface')
                     or _line.startswith('wpa-conf')):
                 new_lines.append(line)
+            elif _line.startswith('iface'):
+                new_lines.append(line)
+                new_lines.append(f'    hostname {hostname}')
             elif _line.startswith('hostname'):
                 if hostname:
                     new_lines.append(f'    hostname {hostname}')
@@ -128,6 +130,7 @@ class EtcNetworkInterfaces:
             else:
                 raise IfError(f'Unexpected config line: {line}')
         return new_lines
+
 
     def set_dhcp(self, ifname: str) -> None:
         ifconf = self._preproc_if(self.conf[ifname])


### PR DESCRIPTION
…ect place

This is my first pull request, so I hope I am doing it correctly.

I have fought with a TurnKey appliance on Proxmox for quite a while to make it register the hostname with my DHCP server.

I found out that the hostname was written below the hotplug interface. When I finally fixed it, I found out that after each reboot something is always removing it again.  It turned out to be the PVE integrations, to prevent it I had to create an ignore file "touch /etc/network/.pve-ignore.interfaces". It should probably be a part of the initial TurnKey config while deploying on Proxmox.

I hope I understood the loop correctly and my edits are OK, feel free to adjust it.

Iam also not sure if how I edited the loop didn't introduce any issue with some other interfaces, but I tested it thoroughly with auto eth0, then with auto lo+auto eth0 combination and finaly with auto lo+auto eth0+allow-hotplug eth1, what is I guess the default for Proxmox PVE.

It would be great if you could include this tweak to the 2.0.6 version before you push it to the APT.

thanks

Lubomir

PS: this is how looks my file now

<interfaces file>
# UNCONFIGURED INTERFACES
# remove the above line if you edit this file

auto lo
iface lo inet loopback

auto eth0
iface eth0 inet dhcp
        hostname wordpressmulti

allow-hotplug eth1
iface eth1 inet dhcp
</interfaces file>