### PR TITLE
More tweaks

### DIFF
--- a/confconsole.py
+++ b/confconsole.py
@@ -507,14 +507,19 @@ class TurnkeyConsole:
             return []
 
         warnings = []
+        addr = None
+        netmask = None
+        gateway = None
+        nameservers = None
         try:
-            addr, netmask, gateway, nameservers = ifutil.get_ipconf(self.ifname, True)
+            addr, netmask, gateway, nameservers \
+                    = ifutil.get_ipconf(self.ifname, True)
         except CalledProcessError:
             warnings.append('`route -n` returned non-0 exit code! (unable to get gateway)')
-            addr, netmask, gateway, nameservers = None, None, '', []
         except netinfo.NetInfoError:
             warnings.append('failed to find default gateway!')
-            addr, netmask, gateway, nameservers = None, None, '', []
+            addr, netmask, none, nameservers \
+                    = ifutil.get_ipconf(self.ifname, False)
 
         if addr is None:
             warnings.append('failed to assertain current address!')
@@ -522,6 +527,10 @@ class TurnkeyConsole:
         if netmask is None:
             warnings.append('failed to assertain current netmask!')
             netmask = ''
+        if gateway is None:
+            gateway = ''
+        if nameservers is None:
+            nameservers = []
 
         if warnings:
             warnings.append('\nWill leave relevant fields blank')

--- a/confconsole.py
+++ b/confconsole.py
@@ -12,23 +12,22 @@ Options:
 
 import os
 import sys
-import dialog
-from dialog import DialogError
-import ipaddr
-from string import Template
-
-import ifutil
-import netinfo
+import subprocess
+from subprocess import CalledProcessError
 import getopt
-
-import conf
-
+import shlex
+from string import Template
 from io import StringIO
 import traceback
-import subprocess
-from subprocess import PIPE, CalledProcessError
-import shlex
 
+import dialog
+from dialog import DialogError
+import traceback
+import netinfo
+
+import ipaddr
+import ifutil
+import conf
 import plugin
 
 PLUGIN_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -253,8 +252,8 @@ class TurnkeyConsole:
         publicip_cmd = conf.Conf().publicip_cmd
         if publicip_cmd:
             command = subprocess.run(shlex.split(publicip_cmd),
-                                     stdout=PIPE,
-                                     encoding='utf-8')
+                                     capture_output=True,
+                                     text=True)
             if command.returncode == 0:
                 return command.stdout.strip()
 
@@ -372,12 +371,12 @@ class TurnkeyConsole:
 
         # tklbam integration
         tklbamstatus_cmd = subprocess.run(['which', 'tklbam-status'],
-                                          stdout=PIPE,
-                                          encoding='utf-8').stdout.strip()
+                                          capture_output=True,
+                                          text=True).stdout.strip()
         if tklbamstatus_cmd:
             tklbam_status = subprocess.run([tklbamstatus_cmd, "--short"],
-                                           stdout=PIPE,
-                                           encoding='utf-8').stdout
+                                           capture_output=True,
+                                           text=True).stdout
         else:
             tklbam_status = ("TKLBAM not found - please check that it's"
                              " installed.")

--- a/ifutil.py
+++ b/ifutil.py
@@ -248,8 +248,7 @@ def ifup(ifname: str) -> str:
 
 
 def ifdown(ifname: str) -> str:
-    return subprocess.check_output(["ip", "link", "set", ifname, "down"],
-                                   capture_output=True, text=True)
+    return subprocess.run(["ip", "link", "set", ifname, "down"])
 
 
 def unconfigure_if(ifname: str) -> Optional[str]:

--- a/ifutil.py
+++ b/ifutil.py
@@ -243,11 +243,13 @@ def get_nameservers(ifname: str) -> list[str]:
 
 
 def ifup(ifname: str) -> str:
-    return subprocess.check_output(["ifup", ifname], text=True)
+    return subprocess.check_output(["ip", "link", "set", ifname, "up"],
+                                   capture_output=True, text=True)
 
 
 def ifdown(ifname: str) -> str:
-    return subprocess.check_output(["ifdown", ifname], text=True)
+    return subprocess.check_output(["ip", "link", "set", ifname, "down"],
+                                   capture_output=True, text=True)
 
 
 def unconfigure_if(ifname: str) -> Optional[str]:


### PR DESCRIPTION
Some more confconsole tweaks.

First is fairly minor (just fixing the import order).
The second has impact on functionality. It allows information gained from the interface to be used where it exists.
The third also has impact on functionality - `ifdown` is no longer reliable (4th is a modification that doesn't check status of bringing the interface down - assumes that failure means that it's not up).