### PR TITLE
Import JSONDecodeError

### DIFF
--- a/plugins.d/Lets_Encrypt/get_certificate.py
+++ b/plugins.d/Lets_Encrypt/get_certificate.py
@@ -7,6 +7,7 @@ import subprocess
 from subprocess import PIPE
 from os import path, remove
 from shutil import copyfile, which
+from json import JSONDecodeError
 
 dns_01 = impByPath('./dns_01.py')
 

--- a/plugins.d/Lets_Encrypt/get_certificate.py
+++ b/plugins.d/Lets_Encrypt/get_certificate.py
@@ -248,7 +248,7 @@ def run():
         # switch to Dehydrated wrapper
         dehydrated_bin = ['bash', path.join(
                             path.dirname(PLUGIN_PATH), 'dehydrated-wrapper'),
-                          '--register', '--challenge', challenge]
+                          '--register', '--log-info', '--challenge', challenge]
         if challenge == 'dns-01':
             dehydrated_bin.append('--provider')
             dehydrated_bin.append(provider)


### PR DESCRIPTION
If the `JSONDecodeError` occurs, instead of a clean error message, you will get an stacktrace (`NameError: name 'JSONDecodeError' is not defined`). Importing it results in a cleaner error message now.

I have also made `get_certificate.py` default to logging info (i.e. passes `--log-info` to `dehydrated-wrapper`). I did that initially to assist with troubleshooting, but considering that either `get_certificate.py` will only be run once (i.e. when it "just works" - in which case a few extra log lines will make virtually no difference) or will be run multiple times (i.e. if there are issues) and having the info logged right from the start will make life easier...