### PR TITLE
Import JSONDecodeError (cherry-picked for v16.x branch)

### DIFF
--- a/plugins.d/Lets_Encrypt/get_certificate.py
+++ b/plugins.d/Lets_Encrypt/get_certificate.py
@@ -183,7 +183,7 @@ def run():
         proc = subprocess.run(
                     ['bash', path.join(
                         path.dirname(PLUGIN_PATH), 'dehydrated-wrapper'),
-                     '--register'],
+                     '--register', '--log-info'],
                     encoding=sys.stdin.encoding,
                     stderr=PIPE)
         if proc.returncode == 0:

--- a/plugins.d/Lets_Encrypt/get_certificate.py
+++ b/plugins.d/Lets_Encrypt/get_certificate.py
@@ -6,6 +6,7 @@ import subprocess
 from subprocess import PIPE
 from os import path, remove
 from shutil import copyfile
+from json import JSONDecodeError
 
 LE_INFO_URL = 'https://acme-v02.api.letsencrypt.org/directory'
 


### PR DESCRIPTION
This is the same fix as in #78 but targeted at the `16.x` (Buster) branch. I should probably do it for the `17.x` branch too...

Also as per #78:
> I have also made `get_certificate.py` default to logging info (i.e. passes `--log-info` to `dehydrated-wrapper`). I did that initially to assist with troubleshooting, but considering that either `get_certificate.py` will only be run once (i.e. when it "just works" - in which case a few extra log lines will make virtually no difference) or will be run multiple times (i.e. if there are issues) and having the info logged right from the start will make life easier...