### PR TITLE
More fixes

### DIFF
--- a/confconsole.py
+++ b/confconsole.py
@@ -193,7 +193,9 @@ class Console:
                           cancel_label=cancel_label)
         assert isinstance(v, tuple)
         assert isinstance(v[1], list)
-        assert isinstance(v[1][1], str)
+        # if the typing is correct, then the below line should never fail
+        # ... but under some circumstance it does... :(
+        #assert isinstance(v[1][1], str)
         return v
 
 

--- a/plugins.d/Lets_Encrypt/dns_01.py
+++ b/plugins.d/Lets_Encrypt/dns_01.py
@@ -97,6 +97,7 @@ def initial_setup() -> None:
     msg_end = '\n\nDo you wish to continue?'
     msg: Optional[str] = ''
     install_venv = False
+    unexpected = False
 
     lexicon_bin = which('turnkey-lexicon')
     venv = '/usr/local/src/venv/lexicon'
@@ -109,13 +110,14 @@ def initial_setup() -> None:
         msg = None
     else:
         msg_mid = "but your system is in an unexpected state"
+        unexpected = True
     if msg is not None:
         msg = msg_start + msg_mid + msg_end
         # console is inherited so doesn't need to be defined
         ret = console.yesno(msg, autosize=True)  # type: ignore[not-defined]
         if ret != 'ok':
             return
-    if install_venv:
+    if install_venv or unexpected:
         pkgs = []
         pip = which('pip')
         python3_venv = check_pkg('python3-venv')

--- a/plugins.d/System_Settings/Secupdates_adv_conf.py
+++ b/plugins.d/System_Settings/Secupdates_adv_conf.py
@@ -2,6 +2,7 @@
 
 import os
 from os.path import exists, islink
+from typing import Optional
 
 FILE_PATH = '/etc/cron-apt/action.d/5-install'
 CONF_DEFAULT = '/etc/cron-apt/action-available.d/5-install.default'
@@ -70,7 +71,7 @@ def button_label(current: str) -> str:
     return f"{msg:^20}"
 
 
-def get_details(choice: str) -> Union[str, None]:
+def get_details(choice: str) -> Optional[str]:
     if choice == 'default':
         return info_default
     elif choice == 'alternate':


### PR DESCRIPTION
This PR contains another tweak (in [`plugins.d/Lets_Encrypt/dns_01.py`](https://github.com/turnkeylinux/confconsole/pull/84/files#diff-0aeb21d27e5302f53685db2d4424b3d581bf45cffb70859e235c9e114c175b0b)) related to the DNS-01 Let's Encrypt challenge - to deal with the situation where a user had already tried to get a cert via DNS-01 and it failed (i.e. using the buggy Confconsole v2.1.3). Without this fix, a user would need to manually clean up their system. Now it will note that the system is in an unexpected state (although it is sort of expected if they ran the buggy v2.1.3 version) and if they proceeds, then it will do the `pip` install of lexicon into the venv.

Also contains a couple of typing fixes (because I hadn't tested properly before!)