### PR TITLE
Set static fix

### DIFF
--- a/ifutil.py
+++ b/ifutil.py
@@ -121,7 +121,8 @@ class EtcNetworkInterfaces:
             elif (_line.startswith('address')
                     or _line.startswith('netmask')
                     or _line.startswith('gateway')
-                    or _line.startswith('dns-nameserver')):
+                    or _line.startswith('dns-nameserver')
+                    or _line.startswith('post-up')):
                 continue
             else:
                 raise IfError(f'Unexpected config line: {line}')

--- a/ifutil.py
+++ b/ifutil.py
@@ -271,13 +271,14 @@ def set_static(ifname: str, addr: str, netmask: str,
                ) -> Optional[str]:
     try:
         ifdown(ifname)
-        interfaces = EtcNetworkInterfaces()
-        interfaces.set_static(ifname, addr, netmask, gateway, nameservers)
+        try:
+            interfaces = EtcNetworkInterfaces()
+            interfaces.set_static(ifname, addr, netmask, gateway, nameservers)
 
-        # FIXME when issue in ifupdown/virtio-net becomes apparent
-        sleep(0.5)
-
-        output = ifup(ifname)
+            # FIXME when issue in ifupdown/virtio-net becomes apparent
+            sleep(0.5)
+        finally:
+            output = ifup(ifname)
 
         net = InterfaceInfo(ifname)
         if not net.address:


### PR DESCRIPTION
Issue is:

1. errors when it encounters a  "post-up" line in the ``/etc/network/interfaces`` file
2. when the error occurs confconsole fails to bring the interface back up, leading to broken networking

This PR solves both of those issues.

Closes https://github.com/turnkeylinux/tracker/issues/2037