### PR TITLE
capture smtp.starttls() ssl.SSLError

### DIFF
--- a/plugins.d/Mail_Relaying/mail_relay.py
+++ b/plugins.d/Mail_Relaying/mail_relay.py
@@ -60,8 +60,8 @@ def testsettings(host, port, login, password):
 
         if ret == 235:
             return True, None
-    except SMTPException as e:
-        ret, msg = e.args[0], e.args[1].decode(encoding)
+    except (ssl.SSLError, SMTPException) as e:
+        ret, msg = e.args[0], bytes2string(e.args[1])
         pass
 
     return False, (ret, msg)


### PR DESCRIPTION
When trying to connect to an old mailserver using the Confconsole Mail Relay module, `smtp.starttls()` raised an `ssl.SSLError` which wasn't being handled. This PR ensure that the exception is handled and the user will get an error message instead. 

I also ensured that `e.args[1]` is always a string as during my testing handling the `ssl.SSLError`, caused an `AttributeError: 'str' object has no attribute 'decode'` in the old code. Leveraging `bytes2string()` means that the message returned will always be a string. Thoughts @OnGle?