### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #! /usr/bin/make -f
 
+export PYTHONDONTWRITEBYTECODE=1
+
 %:
 	dh $@ --with python3,systemd
 


### PR DESCRIPTION
Minimal change to make confconsole reproducible.