### PR TITLE
Add network related logging

### DIFF
--- a/confconsole.py
+++ b/confconsole.py
@@ -10,6 +10,7 @@ Options:
 
 """
 
+import logging
 import os
 import sys
 import subprocess
@@ -22,6 +23,7 @@ import traceback
 
 import dialog
 from dialog import DialogError
+from systemd.journal import JournalHandler
 import netinfo
 
 import ipaddr
@@ -36,19 +38,29 @@ PLUGIN_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "plugins.d"
 )
 
+handler = JournalHandler()
+handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+logging.getLogger().setLevel(logging.DEBUG)
+logging.getLogger().addHandler(handler)
+log = logging.getLogger(__name__)
+
 
 class ConfconsoleError(Exception):
     pass
 
 
 def fatal(msg: str) -> NoReturn:
-    print(f"Error: {msg}", file=sys.stderr)
+    msg = f"Error: {msg}"
+    log.exception(msg)
+    print(msg, file=sys.stderr)
     sys.exit(1)
 
 
 def usage(msg: str | getopt.GetoptError = "") -> NoReturn:
     if msg:
-        print(f"Error: {msg}", file=sys.stderr)
+        msg = f"Error: {msg}"
+        log.exception(msg)
+        print(msg, file=sys.stderr)
 
     print(f"Syntax: {sys.argv[0]}", file=sys.stderr)
     print(USAGE.strip(), file=sys.stderr)
@@ -435,20 +447,29 @@ class TurnkeyConsole:
     def _get_ifconftext(self, ifname: str) -> str:
         addr, netmask, gateway, nameservers = ifutil.get_ipconf(ifname)
         if addr is None:
-            return "Network adapter is not configured\n"
-
+            msg = "Network adapter is not configured"
+            log.warning(msg)
+            return msg + "\n"
+        nameserver_str = " ".join(nameservers)
+        log.info(
+            f"ip: {addr} netmask: {netmask} gateway: {gateway}"
+            f" nameservers: {nameserver_str}",
+        )
         text = f"IP Address:      {addr}\n"
         text += f"Netmask:         {netmask}\n"
         text += f"Default Gateway: {gateway}\n"
-        text += f"Name Server(s):  {' '.join(nameservers)}\n"
+        text += f"Name Server(s):  {nameserver_str}\n"
         ipv6_addr, ipv6_prefix = ifutil.get_ipv6conf(ifname)
         if ipv6_addr:
+            log.info(f"ipv6: {ipv6_addr}/{ipv6_prefix}")
             text += f"IPv6 Address: {ipv6_addr}/{ipv6_prefix}\n"
         text += "\n"
 
         ifmethod = ifutil.get_ifmethod(ifname)
         if ifmethod:
-            text += f"Networking configuration method: {ifmethod}\n"
+            conf_method = f"Networking configuration method: {ifmethod}"
+            log.info(conf_method)
+            text += conf_method + "\n"
 
         if len(self._get_filtered_ifnames()) > 1:
             text += "Is this adapter's IP address displayed in Usage: "
@@ -470,6 +491,7 @@ class TurnkeyConsole:
         # if no interfaces at all - display error and go to advanced
         if len(self._get_filtered_ifnames()) == 0:
             error = "No network adapters detected"
+            log.exception(error)
             if not self.advanced_enabled:
                 fatal(error)
 
@@ -480,6 +502,7 @@ class TurnkeyConsole:
         ifname = self._get_default_nic()
         if not ifname:
             error = "Networking is not yet configured"
+            log.exception(error)
             if not self.advanced_enabled:
                 fatal(error)
 
@@ -502,6 +525,7 @@ class TurnkeyConsole:
             tklbam_status = (
                 "TKLBAM not found - please check that it's installed."
             )
+        log.info(tklbam_status)
 
         # display usage
         ip_addr = self._get_public_ipaddr()
@@ -522,11 +546,15 @@ class TurnkeyConsole:
             t = ""
             text = Template(t).safe_substitute(ipaddr=ip_addr)
 
+        log_msg = f"Usage started - hostname: {hostname} ip: {ip_addr}"
+
         if ipv6_addr:
             text += "\n"
             text += f"\nIPv6 Web:  https://[{ipv6_addr}]"
             text += f"\nIPv6 SSH:  root@{ipv6_addr}"
+            log_msg = log_msg + f" ipv6: {ipv6_addr}"
 
+        log.info(log_msg)
         gap = self.height - len(text.splitlines()) - 11
         gap = gap if gap >= 1 else 1
 
@@ -574,9 +602,11 @@ class TurnkeyConsole:
 
         # if no interfaces at all - display error and go to advanced
         if len(ifnames) == 0:
+            log.warning("no interfaces found")
             self.console.msgbox("Error", "No network adapters detected")
             return "advanced"
 
+        log.info(f"{len(ifnames)} interface/s found: {', '.join(ifnames)}")
         # if only 1 interface, dont display menu - just configure it
         if len(ifnames) == 1:
             self.ifname = ifnames[0]
@@ -613,12 +643,14 @@ class TurnkeyConsole:
         return "_ifconf_" + choice.lower()
 
     def _ifconf_staticip(self) -> str:
+        log_msg = "Applying static ip"
+        log.info(log_msg)
         def _validate(
             addr: str, netmask: str, gateway: str, nameservers: list[str]
         ) -> list[str]:
             """Validate Static IP form parameters. Returns an empty array on
             success, an array of strings describing errors otherwise"""
-
+            log_valid_msg = f"{log_msg} {addr}"
             errors = []
             if not addr:
                 errors.append("No IP address provided")
@@ -638,17 +670,22 @@ class TurnkeyConsole:
                 errors.append("Duplicate nameservers specified")
 
             if errors:
+                log.exception(f"{log_valid_msg} failed: {', '.join(errors)}")
                 return errors
 
             if gateway:
                 if not ipaddr.is_legal_ip(gateway):
-                    return [f"Invalid gateway: {gateway}"]
+                    error = f"Invalid gateway: {gateway}"
+                    log.exception(f"{log_valid_msg} failed: {error}")
+                    return [error]
                 else:
                     iprange = ipaddr.IPRange(addr, netmask)
                     if gateway not in iprange:
-                        return [
+                        error = \
                             f"Gateway ({gateway}) not in IP range ({iprange})"
-                        ]
+                        log.exception(f"{log_valid_msg} failed: {error}")
+                        return [error]
+
             return []
 
         warnings = []
@@ -682,10 +719,12 @@ class TurnkeyConsole:
             nameservers = []
 
         if warnings:
-            warnings.append("\nWill leave relevant fields blank")
-
-        if warnings:
-            self.console.msgbox("Warning", "\n".join(warnings))
+            warning_last_line = "Will leave relevant fields blank"
+            log.warning(f"{log_msg} warning/s: {', '.join(warnings)}")
+            log.warning(warning_last_line)
+            self.console.msgbox(
+                "Warning", "\n".join([*warnings, warning_last_line]),
+            )
 
         value = [addr, netmask, gateway]
         value.extend(nameservers)

--- a/ifutil.py
+++ b/ifutil.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass, field
-import subprocess
-from time import sleep
 import os
 import re
+import subprocess
+from dataclasses import dataclass
+from time import sleep
 
 from netinfo import InterfaceInfo
 from netinfo import get_hostname
@@ -251,6 +251,7 @@ class NetworkInterfaces:
                 line_list = line.strip().split()
                 if line_list[0] == key:
                     return line_list[1:]
+        return None
 
     def get_nameservers(self, ifname: str) -> list[str] | None:
         return self.get_if_conf(ifname, "dns-nameservers") or []
@@ -259,11 +260,13 @@ class NetworkInterfaces:
         addr = self.get_if_conf(ifname, "address")
         if addr:
             return addr[0]
+        return None
 
     def get_netmask(self, ifname: str) -> str | None:
         addr = self.get_if_conf(ifname, "netmask")
         if addr:
             return addr[0]
+        return None
 
 
 def _parse_resolv(path: str) -> list[str]:
@@ -362,6 +365,7 @@ def unconfigure_if(ifname: str) -> str | None:
         ifup(ifname, force=True)
 
         return str(e)
+    return None
 
 
 def set_static(
@@ -440,7 +444,6 @@ def get_ipconf(
     return (None, None, net.get_gateway(error), get_nameservers(ifname))
 
 
-
 def get_ipv6conf(ifname: str) -> tuple[str | None, str | None]:
     """Get IPv6 global address and prefix for an interface."""
     try:
@@ -459,9 +462,11 @@ def get_ipv6conf(ifname: str) -> tuple[str | None, str | None]:
         pass
     return (None, None)
 
+
 def get_ifmethod(ifname: str) -> str | None:
     interfaces = NetworkInterfaces()
     interfaces.read()
     conf_line = interfaces.get_if_conf(ifname, "iface")
     if conf_line:
         return conf_line[3]
+    return None


### PR DESCRIPTION
Add initial logging. Currently only for network related functionality in `confconsole`.

More tweaks are required to Confconsole for IPv6 and cleanly handling DHCP (now we've switched to `dhcpcd`). Those changes will be in another PR, but I wanted to be able to easily troubleshoot and/or confirm it's working as intended but I wanted to separate the initial logging setup (and the minor linting updates) in their own PR.

Further extending Confconsole logging is probably desirable but low priority for now IMO.

Specific changes:
- lint `ifutil.py` - https://github.com/turnkeylinux/confconsole/commit/d6bbfb6647dbf228a8eacd95e236bdc98c9adda1
- add logging for network related functionality in confconsole - https://github.com/turnkeylinux/confconsole/commit/ea294ccd8a9b8091b95f9ac79b9230cb94d38c2b

