### PR TITLE
WIP More dhcpcd related networking updates

### DIFF
--- a/confconsole.py
+++ b/confconsole.py
@@ -10,6 +10,7 @@ Options:
 
 """
 
+import logging
 import os
 import sys
 import subprocess
@@ -22,6 +23,7 @@ import traceback
 
 import dialog
 from dialog import DialogError
+from systemd.journal import JournalHandler
 import netinfo
 
 import ipaddr
@@ -36,19 +38,29 @@ PLUGIN_PATH = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "plugins.d"
 )
 
+handler = JournalHandler()
+handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+logging.getLogger().setLevel(logging.DEBUG)
+logging.getLogger().addHandler(handler)
+log = logging.getLogger(__name__)
+
 
 class ConfconsoleError(Exception):
     pass
 
 
 def fatal(msg: str) -> NoReturn:
-    print(f"Error: {msg}", file=sys.stderr)
+    msg = f"Error: {msg}"
+    log.exception(msg)
+    print(msg, file=sys.stderr)
     sys.exit(1)
 
 
 def usage(msg: str | getopt.GetoptError = "") -> NoReturn:
     if msg:
-        print(f"Error: {msg}", file=sys.stderr)
+        msg = f"Error: {msg}"
+        log.exception(msg)
+        print(msg, file=sys.stderr)
 
     print(f"Syntax: {sys.argv[0]}", file=sys.stderr)
     print(USAGE.strip(), file=sys.stderr)
@@ -435,20 +447,29 @@ class TurnkeyConsole:
     def _get_ifconftext(self, ifname: str) -> str:
         addr, netmask, gateway, nameservers = ifutil.get_ipconf(ifname)
         if addr is None:
-            return "Network adapter is not configured\n"
-
+            msg = "Network adapter is not configured"
+            log.warning(msg)
+            return msg + "\n"
+        nameserver_str = " ".join(nameservers)
+        log.info(
+            f"ip: {addr} netmask: {netmask} gateway: {gateway}"
+            f" nameservers: {nameserver_str}",
+        )
         text = f"IP Address:      {addr}\n"
         text += f"Netmask:         {netmask}\n"
         text += f"Default Gateway: {gateway}\n"
-        text += f"Name Server(s):  {' '.join(nameservers)}\n"
+        text += f"Name Server(s):  {nameserver_str}\n"
         ipv6_addr, ipv6_prefix = ifutil.get_ipv6conf(ifname)
         if ipv6_addr:
+            log.info(f"ipv6: {ipv6_addr}/{ipv6_prefix}")
             text += f"IPv6 Address: {ipv6_addr}/{ipv6_prefix}\n"
         text += "\n"
 
         ifmethod = ifutil.get_ifmethod(ifname)
         if ifmethod:
-            text += f"Networking configuration method: {ifmethod}\n"
+            conf_method = f"Networking configuration method: {ifmethod}"
+            log.info(conf_method)
+            text += conf_method + "\n"
 
         if len(self._get_filtered_ifnames()) > 1:
             text += "Is this adapter's IP address displayed in Usage: "
@@ -470,6 +491,7 @@ class TurnkeyConsole:
         # if no interfaces at all - display error and go to advanced
         if len(self._get_filtered_ifnames()) == 0:
             error = "No network adapters detected"
+            log.exception(error)
             if not self.advanced_enabled:
                 fatal(error)
 
@@ -480,6 +502,7 @@ class TurnkeyConsole:
         ifname = self._get_default_nic()
         if not ifname:
             error = "Networking is not yet configured"
+            log.exception(error)
             if not self.advanced_enabled:
                 fatal(error)
 
@@ -502,6 +525,7 @@ class TurnkeyConsole:
             tklbam_status = (
                 "TKLBAM not found - please check that it's installed."
             )
+        log.info(tklbam_status)
 
         # display usage
         ip_addr = self._get_public_ipaddr()
@@ -522,11 +546,15 @@ class TurnkeyConsole:
             t = ""
             text = Template(t).safe_substitute(ipaddr=ip_addr)
 
+        log_msg = f"Usage started - hostname: {hostname} ip: {ip_addr}"
+
         if ipv6_addr:
             text += "\n"
             text += f"\nIPv6 Web:  https://[{ipv6_addr}]"
             text += f"\nIPv6 SSH:  root@{ipv6_addr}"
+            log_msg = log_msg + f" ipv6: {ipv6_addr}"
 
+        log.info(log_msg)
         gap = self.height - len(text.splitlines()) - 11
         gap = gap if gap >= 1 else 1
 
@@ -574,9 +602,11 @@ class TurnkeyConsole:
 
         # if no interfaces at all - display error and go to advanced
         if len(ifnames) == 0:
+            log.warning("no interfaces found")
             self.console.msgbox("Error", "No network adapters detected")
             return "advanced"
 
+        log.info(f"{len(ifnames)} interface/s found: {', '.join(ifnames)}")
         # if only 1 interface, dont display menu - just configure it
         if len(ifnames) == 1:
             self.ifname = ifnames[0]
@@ -613,12 +643,14 @@ class TurnkeyConsole:
         return "_ifconf_" + choice.lower()
 
     def _ifconf_staticip(self) -> str:
+        log_msg = "Applying static ip"
+        log.info(log_msg)
         def _validate(
             addr: str, netmask: str, gateway: str, nameservers: list[str]
         ) -> list[str]:
             """Validate Static IP form parameters. Returns an empty array on
             success, an array of strings describing errors otherwise"""
-
+            log_valid_msg = f"{log_msg} {addr}"
             errors = []
             if not addr:
                 errors.append("No IP address provided")
@@ -638,17 +670,22 @@ class TurnkeyConsole:
                 errors.append("Duplicate nameservers specified")
 
             if errors:
+                log.exception(f"{log_valid_msg} failed: {', '.join(errors)}")
                 return errors
 
             if gateway:
                 if not ipaddr.is_legal_ip(gateway):
-                    return [f"Invalid gateway: {gateway}"]
+                    error = f"Invalid gateway: {gateway}"
+                    log.exception(f"{log_valid_msg} failed: {error}")
+                    return [error]
                 else:
                     iprange = ipaddr.IPRange(addr, netmask)
                     if gateway not in iprange:
-                        return [
+                        error = \
                             f"Gateway ({gateway}) not in IP range ({iprange})"
-                        ]
+                        log.exception(f"{log_valid_msg} failed: {error}")
+                        return [error]
+
             return []
 
         warnings = []
@@ -682,10 +719,12 @@ class TurnkeyConsole:
             nameservers = []
 
         if warnings:
-            warnings.append("\nWill leave relevant fields blank")
-
-        if warnings:
-            self.console.msgbox("Warning", "\n".join(warnings))
+            warning_last_line = "Will leave relevant fields blank"
+            log.warning(f"{log_msg} warning/s: {', '.join(warnings)}")
+            log.warning(warning_last_line)
+            self.console.msgbox(
+                "Warning", "\n".join([*warnings, warning_last_line]),
+            )
 
         value = [addr, netmask, gateway]
         value.extend(nameservers)

--- a/ifutil.py
+++ b/ifutil.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass, field
-import subprocess
-from time import sleep
 import os
 import re
+import subprocess
+from dataclasses import dataclass
+from time import sleep
 
 from netinfo import InterfaceInfo
 from netinfo import get_hostname
@@ -251,6 +251,7 @@ class NetworkInterfaces:
                 line_list = line.strip().split()
                 if line_list[0] == key:
                     return line_list[1:]
+        return None
 
     def get_nameservers(self, ifname: str) -> list[str] | None:
         return self.get_if_conf(ifname, "dns-nameservers") or []
@@ -259,11 +260,13 @@ class NetworkInterfaces:
         addr = self.get_if_conf(ifname, "address")
         if addr:
             return addr[0]
+        return None
 
     def get_netmask(self, ifname: str) -> str | None:
         addr = self.get_if_conf(ifname, "netmask")
         if addr:
             return addr[0]
+        return None
 
 
 def _parse_resolv(path: str) -> list[str]:
@@ -362,6 +365,7 @@ def unconfigure_if(ifname: str) -> str | None:
         ifup(ifname, force=True)
 
         return str(e)
+    return None
 
 
 def set_static(
@@ -440,7 +444,6 @@ def get_ipconf(
     return (None, None, net.get_gateway(error), get_nameservers(ifname))
 
 
-
 def get_ipv6conf(ifname: str) -> tuple[str | None, str | None]:
     """Get IPv6 global address and prefix for an interface."""
     try:
@@ -459,9 +462,11 @@ def get_ipv6conf(ifname: str) -> tuple[str | None, str | None]:
         pass
     return (None, None)
 
+
 def get_ifmethod(ifname: str) -> str | None:
     interfaces = NetworkInterfaces()
     interfaces.read()
     conf_line = interfaces.get_if_conf(ifname, "iface")
     if conf_line:
         return conf_line[3]
+    return None

--- a/ifutil.py
+++ b/ifutil.py
@@ -1,11 +1,16 @@
+import logging
 import os
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass
+from os.path import isfile
 from time import sleep
 
 from netinfo import InterfaceInfo
 from netinfo import get_hostname
+
+log = logging.getLogger(__name__)
 
 
 class IfError(Exception):
@@ -28,8 +33,127 @@ class BadIfConfigError(IfError):
     pass
 
 
+class DHCPError(IfError):
+    pass
+
+
 IPV4_RE = r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(.*)$"
 IPV4_CIDR = r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})(.*)$"
+
+
+def _etckeeper_commit(msg: str) -> None:
+    etckeeper = shutil.which("etckeeper")
+    if not etckeeper:
+        log.warning("etckeeper not found, current /etc config not commited")
+        return
+    commit_conf_cmd = subprocess.run(
+        [
+            etckeeper,
+            "commit",
+            msg
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if commit_conf_cmd.returncode != 0:
+        log.exception(
+            f"'etckeeper commit' failed: {commit_conf_cmd.stderr}",
+        )
+    else:
+        log.info("Current /etc config committed by etckeeper")
+
+
+def _backup_conf(conf_path: str) -> None:
+    if not isfile(conf_path):
+        log.exception(f"File not found: {conf_path} - can't backup.")
+        return
+    if isfile(conf_path):
+        shutil.copy2(conf_path, f"{conf_path}.bak")
+        _etckeeper_commit(f"Commit {conf_path}.bak prior to update")
+        log.info(f"Created backup of {conf_path}")
+
+
+def _dhcp_ipv4(interface: str, action: str) -> None:
+    """
+    Enable or disable network interface IPv4 DHCP in dhcpcd.conf.
+
+    Effort is made to reduce risk of 
+    Note that this is somewhat fragile as only the exact block of text is
+    handled. If the dhcp config file has been modified manually there is risk
+    that the config may not be removed or be added again.
+
+    Args:
+        interface: Network interface name (e.g. 'eth0')
+        action: "enable" to remove the noipv4 block, "disable" to add it
+    """
+    if action not in ("enable", "disable"):
+        raise ValueError(
+            f"action must be 'enable' or 'disable', got: {action!r}",
+        )
+
+    config_path = '/etc/dhcpcd.conf'
+    _backup_conf(config_path)
+    disable_block = [
+        f"# static {interface} ipv4",
+        f"interface {interface}",
+        "    noipv4",
+    ]
+
+    with open(config_path) as fob:
+        conf_lines = fob.readlines()
+
+    conf_stripped = [line.rstrip('\n') for line in conf_lines]
+
+    # Find the index of the 3-line block (if it exists)
+    block_start = None
+    for i in range(len(conf_stripped) - 2):
+        if conf_stripped[i:i+3] == disable_block:
+            block_start = i
+            break
+
+    if action == "disable":
+        if block_start is not None:
+            log.info(f"{interface} DHCP already disabled - nothing to do")
+            return
+
+        # Double check for any existing "interface {interface}" line to
+        # reduce risk if user has manually edited conf (whitespace-tolerant)
+        interface_pattern = re.compile(
+            r"^\s*interface\s+" + re.escape(interface) + r"\s*$"
+        )
+        for line in conf_stripped:
+            if interface_pattern.match(line):
+                msg = (
+                    f"Cannot disable IPv4 for '{interface}': an 'interface"
+                    f" {interface}' entry already exists in {config_path}"
+                    " without the expected noipv4 block."
+                )
+                log.exception(msg)
+                raise RuntimeError(msg)
+
+        # Append the block - with a leading blank line if file doesn't end
+        # with one
+        new_lines = conf_lines[:]
+        if new_lines and new_lines[-1].rstrip("\n") != "":
+            new_lines.append("\n")
+        new_lines.extend(line + "\n" for line in disable_block)
+
+    elif action == "enable":
+        if block_start is None:
+            log.info(f"{interface} DHCP already enabled - nothing to do")
+            return
+        # Remove the 3 disable_block lines, and any immediately preceding
+        # blank line
+        start = block_start
+        if start > 0 and conf_stripped[start - 1] == "":
+            start -= 1
+        new_lines = conf_lines[:start] + conf_lines[block_start + 3:]
+
+    log.info(f"Updating {config_path}")
+    with open(config_path, "w") as fob:
+        fob.writelines(new_lines)
+    log.info(f"{config_path} updated to {action} DHCP")
+    _etckeeper_commit(f"Commit updated {config_path}.")
 
 
 def _preprocess_interface_config(config: str) -> list[str]:
@@ -55,7 +179,9 @@ def _preprocess_interface_config(config: str) -> list[str]:
         ):
             continue
         else:
-            raise BadIfConfigError(f"Unexpected config line: {line}")
+            msg = f"Unexpected config line: {line}"
+            log.exception(msg)
+            raise BadIfConfigError(msg)
     if len(new_lines) == 2 and hostname:
         new_lines.append(f"    hostname {hostname}")
     return new_lines
@@ -184,15 +310,17 @@ class NetworkInterfaces:
                 f"refusing to write to {self.CONF_FILE}\n"
                 f"header not found: {self.HEADER_UNCONFIGURED}"
             )
-
+        _backup_conf(self.CONF_FILE)
         with open(self.CONF_FILE, "w") as fob:
             fob.write(self.HEADER_UNCONFIGURED + "\n")
             for iface in self.conf.keys():
                 fob.write("\n\n")
                 fob.write("\n".join(self.conf[iface]))
                 fob.write("\n")
+        _etckeeper_commit(f"Commit /etc after update of {self.CONF_FILE}")
 
     def gen_default_if_config(self, ifname: str) -> None:
+        # TODO: add support for ipv6
         if ifname.startswith("e"):
             self.conf[ifname] = _preprocess_interface_config(
                 f"auto {ifname}\niface {ifname} inet dhcp"
@@ -207,10 +335,12 @@ class NetworkInterfaces:
         ifconf = _preprocess_interface_config("\n".join(self.conf[ifname]))
         ifconf[1] = f"iface {ifname} inet dhcp"
         self.conf[ifname] = ifconf
-
         self.write()
+        _dhcp_ipv4(ifname, "enable")
+
 
     def set_manual(self, ifname: str) -> None:
+        # TODO: handle DHCP config for manual interface
         if ifname not in self.conf:
             self.gen_default_if_config(ifname)
 
@@ -244,6 +374,7 @@ class NetworkInterfaces:
 
         self.conf[ifname] = ifconf
         self.write()
+        _dhcp_ipv4(ifname, "disable")
 
     def get_if_conf(self, ifname: str, key: str) -> list[str] | None:
         if ifname in self.conf:


### PR DESCRIPTION
This PR adds management of `dhcpcd` config when a network interface is reconfigured to use a static IP (or reset to DHCP after having been static) via Confconsole.

Despite `dhcpcd` being "compatible" with `ifupdown` & `/etc/network/interfaces` file, it does not honor DHCP related config in the interfaces file so `/etc/dhcpcd.conf` needs to be configured explicitly to disable DHCP. Otherwise if an interface is set to static in the interfaces file it will still also use DHCP - resulting in 2 IP addresses plus other info from DHCP.

FYI Confconsole still only handles IPv4 WRT DHCP - IPv6 is "hardcoded" as DHCP & if set to a static IP via /etc/interfaces file it will still get network config from DHCP - assuming it can.